### PR TITLE
Load cleaned facility dataset by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This repository contains data and utilities for processing aggregate facility in
 ## Files
 
 - `AGGDATA.csv` – Raw facility data exported from LIMS.
-- `index.html` – Prototype web map interface.
+- `AGGDATA_cleaned.csv` – Deduplicated records used by the map interface.
+- `index.html` – Prototype web map interface that loads `AGGDATA_cleaned.csv` by default.
 - `merge_duplicates.py` – Utility script that merges duplicate facility records.
 
 ## Merging Duplicate Rows

--- a/index.html
+++ b/index.html
@@ -71,10 +71,6 @@
   <div class="container mx-auto p-4">
     <h1 class="text-2xl font-bold mb-4">Construction Coordinate Map with Material Type Filter</h1>
     <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700">Upload CSV File</label>
-      <input type="file" id="fileInput" accept=".csv" class="mt-1 block w-full p-2 border border-gray-300 rounded-md">
-    </div>
-    <div class="mb-4">
       <label class="block text-sm font-medium text-gray-700">Filter by Material Type</label>
       <select id="materialTypeFilter" multiple class="mt-1 block w-full"></select>
     </div>
@@ -187,8 +183,8 @@ function updateMarkers() {
   });
 }
 
-// Load default dataset
-fetch('AGGDATA.csv')
+// Load dataset shipped with the application
+fetch('AGGDATA_cleaned.csv')
   .then(r => r.text())
   .then(text => {
     Papa.parse(text, {
@@ -197,16 +193,6 @@ fetch('AGGDATA.csv')
       complete: res => addMarkers(res.data)
     });
   });
-
-document.getElementById('fileInput').addEventListener('change', e => {
-  const file = e.target.files[0];
-  if (!file) return;
-  Papa.parse(file, {
-    header: true,
-    skipEmptyLines: true,
-    complete: res => addMarkers(res.data)
-  });
-});
 
 $(document).ready(function () {
   const $select = $('#materialTypeFilter');


### PR DESCRIPTION
## Summary
- remove CSV upload field and use the repository dataset
- load `AGGDATA_cleaned.csv` in the map interface
- document the cleaned dataset in the README

## Testing
- `python3 -m py_compile merge_duplicates.py`

------
https://chatgpt.com/codex/tasks/task_e_688909207094832ba55212a28bdcaca2