### PR TITLE
Improve map layout and checkbox filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js"></script>
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css" />
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
   <style>
     /* Custom styles for Leaflet popup */
     .leaflet-popup-content-wrapper {
@@ -42,46 +40,36 @@
     .leaflet-popup-tip {
       background-color: #ffffff;
     }
-    /* Custom styles for Select2 */
-    .select2-container .select2-selection--multiple {
-      border: 1px solid #d1d5db;
-      border-radius: 4px;
-      min-height: 38px;
+    /* Layout for full screen map */
+    body, html {
+      height: 100%;
+      margin: 0;
     }
-    .select2-container--default .select2-selection--multiple .select2-selection__rendered {
-      padding: 4px 8px;
+    #map {
+      height: 100%;
+      width: 100%;
     }
-    .select2-container--default .select2-selection--multiple .select2-selection__choice {
-      background-color: #e5e7eb;
-      border: 1px solid #d1d5db;
-      border-radius: 4px;
-      padding: 2px 8px;
-      margin: 2px;
-    }
-    .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
-      color: #6b7280;
-      margin-right: 4px;
-    }
-    .select2-container {
-      width: 100% !important;
+    #controls {
+      max-height: calc(100vh - 2rem);
+      overflow-y: auto;
     }
   </style>
 </head>
-<body class="bg-gray-100">
-  <div class="container mx-auto p-4">
-    <h1 class="text-2xl font-bold mb-4">Construction Coordinate Map with Material Type Filter</h1>
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700">Filter by Material Type</label>
-      <select id="materialTypeFilter" multiple class="mt-1 block w-full"></select>
+<body class="bg-gray-100 h-screen relative">
+  <div id="map"></div>
+  <div id="controls" class="absolute top-0 left-0 m-4 p-4 bg-white rounded shadow w-72">
+    <h1 class="text-xl font-bold mb-2">Construction Coordinate Map</h1>
+    <div class="mb-2">
+      <label class="block text-sm font-medium text-gray-700 mb-1">Filter by Material Type</label>
+      <div id="materialTypeFilter" class="space-y-1"></div>
     </div>
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700">Search Radius: <span id="radiusValue">10</span> miles</label>
+    <div class="mb-2">
+      <label class="block text-sm font-medium text-gray-700 mb-1">Search Radius: <span id="radiusValue">10</span> miles</label>
       <input type="range" id="radiusSlider" min="1" max="50" value="10" class="w-full">
     </div>
-    <div class="mb-4">
+    <div class="mb-2">
       <p class="text-sm text-gray-600">Click on the map to choose a location. Markers within the selected radius will appear. <button id="resetView" class="text-blue-500 underline">Reset</button></p>
     </div>
-    <div id="map" class="h-96 w-full mt-4"></div>
   </div>
 
   <script>
@@ -180,7 +168,7 @@ function addMarkers(rows) {
 function updateMarkers() {
   markers.forEach(m => map.removeLayer(m));
   if (!selectedLatLng) return;
-  const types = $('#materialTypeFilter').val() || [];
+  const types = $('.material-checkbox:checked').map((_, el) => el.value).get();
   markers.forEach(m => {
     const inType = !types.length || types.includes(m.material);
     const inRadius = selectedLatLng.distanceTo(m.getLatLng()) <= searchRadius;
@@ -202,14 +190,21 @@ fetch('AGGDATA_cleaned.csv')
   });
 
 $(document).ready(function () {
-  const $select = $('#materialTypeFilter');
+  const $container = $('#materialTypeFilter');
   for (const [group, opts] of Object.entries(materialTypeCategories)) {
-    const $group = $('<optgroup>').attr('label', group);
-    opts.forEach(v => $group.append($('<option>').val(v).text(v)));
-    $select.append($group);
+    if (!opts.length) continue;
+    const $group = $('<div class="mb-1">');
+    $group.append($('<div class="font-semibold">').text(group));
+    opts.forEach(v => {
+      const id = 'mat_' + v.replace(/\s+/g, '_');
+      const $label = $('<label class="flex items-center space-x-2">');
+      const $checkbox = $('<input type="checkbox" class="material-checkbox">').val(v).attr('id', id);
+      $label.append($checkbox).append($('<span>').text(v));
+      $group.append($label);
+    });
+    $container.append($group);
   }
-  $select.select2();
-  $select.on('change', () => updateMarkers());
+  $('.material-checkbox').on('change', updateMarkers);
   const slider = document.getElementById('radiusSlider');
   const radiusText = document.getElementById('radiusValue');
   slider.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- make the map take the full browser window
- overlay controls and use checkboxes for material filtering

## Testing
- `python -m py_compile merge_duplicates.py`


------
https://chatgpt.com/codex/tasks/task_e_68890c877a18832ba993d0807b3621a0