### PR TITLE
Add shortlist feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,23 @@
       <div class="mb-4">
         <p class="text-sm text-gray-600">Click on the map to choose a location. Markers within the selected radius will appear. <button id="resetView" class="text-blue-500 underline">Reset</button></p>
       </div>
+      <div class="mt-4">
+        <h2 class="text-lg font-semibold mb-2">Shortlist</h2>
+        <table id="shortlist" class="min-w-full text-sm border">
+          <thead class="bg-gray-200">
+            <tr>
+              <th class="border px-2 py-1">Company</th>
+              <th class="border px-2 py-1">Facility</th>
+              <th class="border px-2 py-1">Material</th>
+              <th class="border px-2 py-1">Contact</th>
+              <th class="border px-2 py-1">Email</th>
+              <th class="border px-2 py-1">Phone</th>
+              <th class="border px-2 py-1">Products</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
     </div>
     <div id="map"></div>
 
@@ -146,9 +163,12 @@ function addMarkers(rows) {
     const popup = `<h3>${row.Company || ''}</h3>` +
       `<p><strong>Facility:</strong> ${row['Facility Description'] || ''}</p>` +
       `<p><strong>Material:</strong> ${row['Material Type'] || ''}</p>` +
+      `<p><strong>Products:</strong> ${row['Products.Description'] || ''}</p>` +
+      `<button class="add-shortlist bg-green-500 text-white px-2 py-1 rounded mt-2 mr-2">Add to Shortlist</button>` +
       `<button class="contact-btn bg-blue-500 text-white px-2 py-1 rounded mt-2">Contact Information</button>` +
       contactInfo;
     marker.bindPopup(popup);
+    marker.rowData = row;
     markers.push(marker);
   });
   updateMarkers();
@@ -165,6 +185,18 @@ function updateMarkers() {
       m.addTo(map);
     }
   });
+}
+
+function addToShortlist(row) {
+  const $tr = $('<tr>');
+  $tr.append($('<td>').addClass('border px-2 py-1').text(row.Company || ''));
+  $tr.append($('<td>').addClass('border px-2 py-1').text(row['Facility Description'] || ''));
+  $tr.append($('<td>').addClass('border px-2 py-1').text(row['Material Type'] || ''));
+  $tr.append($('<td>').addClass('border px-2 py-1').text(row['Contact Person'] || ''));
+  $tr.append($('<td>').addClass('border px-2 py-1').text(row['Contact Email'] || ''));
+  $tr.append($('<td>').addClass('border px-2 py-1').text(row['Telephone Number'] || ''));
+  $tr.append($('<td>').addClass('border px-2 py-1').text(row['Products.Description'] || ''));
+  $('#shortlist tbody').append($tr);
 }
 
 // Load dataset shipped with the application
@@ -207,6 +239,9 @@ map.on('popupopen', e => {
   const $popup = $(e.popup.getElement());
   $popup.find('.contact-btn').on('click', () => {
     $popup.find('.contact-info').toggleClass('hidden');
+  });
+  $popup.find('.add-shortlist').on('click', () => {
+    addToShortlist(e.popup._source.rowData);
   });
 });
 


### PR DESCRIPTION
## Summary
- create a shortlist table in the sidebar
- allow markers to be added to the shortlist from the popup
- include contact info and product descriptions in popups and shortlist

## Testing
- `python3 -m py_compile merge_duplicates.py`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68891d8e3a80832b93107ca322839bf7